### PR TITLE
feat: support %IPM 0.9+

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -4,7 +4,7 @@
     <Module>
       <Name>zbash</Name>
       <GlobalScope>true</GlobalScope>
-      <Version>0.0.5</Version>
+      <Version>0.0.6</Version>
       <Description>Use bash from the intersystems terminal</Description>
       <Keywords>bash terminal</Keywords>
       <Packaging>module</Packaging>

--- a/src/%ZBASH/zbash.cls
+++ b/src/%ZBASH/zbash.cls
@@ -1,5 +1,3 @@
-Include %ZPM.PackageManager.Common
-
 /// Used for version check
 Class %ZBASH.zbash
 {


### PR DESCRIPTION
Hi @nickmitchko . InterSystems is going to roll out a newer version of package manager, IPM, which introduces new features and breaking changes. One of such change is that we renamed the whole %ZPM package to %IPM. This PR ensures that this package will be compatible with both older and newer version of the package manager.